### PR TITLE
feat: 웹 스크래핑 후 book description추가

### DIFF
--- a/meta-bookdstore/build.gradle
+++ b/meta-bookdstore/build.gradle
@@ -50,6 +50,7 @@ dependencies {
 	annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	implementation group: 'org.jsoup', name: 'jsoup', version: '1.11.3'
 }
 	
 test {

--- a/meta-bookdstore/src/main/java/com/meta/api2/controller/ApiController.java
+++ b/meta-bookdstore/src/main/java/com/meta/api2/controller/ApiController.java
@@ -12,6 +12,10 @@ import java.net.URLEncoder;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.jsoup.select.Elements;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.configurationprocessor.json.JSONArray;
 import org.springframework.boot.configurationprocessor.json.JSONObject;
@@ -68,11 +72,26 @@ public class ApiController {
 				
 				//카테고리 넘버입력(파라미터에서 값 받아옴) 
 				apiVo.setCate_no(no);
+				String scrappingUrl = apiVo.getLink();
+				try {
+				
+				Document document = Jsoup.connect(scrappingUrl).get();
+				Elements container = document.getElementById("bookIntroContent").getElementsByTag("p");
+				String description = container.toString();
+				
+				apiVo.setDescription(description);
 
 				//데이터 DB삽입 
-				apiService.insert(apiVo);
+			
+				}catch(Exception e) {
+					System.out.println("error : " + scrappingUrl);
+					apiVo.setDescription("");
+				}finally{
+					index++;
+					apiService.insert(apiVo);
+				}
 
-				index++;
+			
 			}
 
 		} catch (Exception e) {
@@ -80,7 +99,6 @@ public class ApiController {
 			e.printStackTrace();
 		}
 
-		System.out.println(">>");
 
 	}
 

--- a/meta-bookdstore/src/main/java/com/meta/api2/vo/ApiVo.java
+++ b/meta-bookdstore/src/main/java/com/meta/api2/vo/ApiVo.java
@@ -13,5 +13,6 @@ public class ApiVo {
 	private String publisher;
 	private String pubdate;
 	private String description;
+	private String link;
 	private int cate_no;
 }

--- a/meta-bookdstore/src/main/java/com/meta/book/controller/BookController.java
+++ b/meta-bookdstore/src/main/java/com/meta/book/controller/BookController.java
@@ -12,6 +12,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import com.meta.book.service.BookService;
 
 
+
 @Controller
 @RequestMapping("/book")
 public class BookController {

--- a/meta-bookdstore/src/main/java/com/meta/cart/controller/CartController.java
+++ b/meta-bookdstore/src/main/java/com/meta/cart/controller/CartController.java
@@ -37,7 +37,8 @@ public class CartController {
 	@ResponseBody
 	public String addCart(@AuthenticationPrincipal PrincipalDetails principalDetails, @ModelAttribute CartVO cartVo) {
 		long memberId = principalDetails != null ? principalDetails.getMember().getM_no() : 0;
-
+		
+		System.out.println("add to cart >> "+memberId);
 		if (memberId != 0) {
 			cartVo.setM_no(memberId);
 			if (cartService.checkIfCartExisted(cartVo)) {

--- a/meta-bookdstore/src/main/java/com/meta/config/SecurityConfig.java
+++ b/meta-bookdstore/src/main/java/com/meta/config/SecurityConfig.java
@@ -44,6 +44,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter{
 		http.authorizeRequests()
 			//.antMatchers("/admin/**").access("hasRole('ROLE_ADMIN')")
 			.antMatchers("/order/**").authenticated()//로그인 해야 order페이지 접근가능
+			.antMatchers("/cart/add").permitAll()
 			.antMatchers("/cart/**").authenticated()
 			.anyRequest().permitAll(); 
 		

--- a/meta-bookdstore/src/main/resources/mapper/OrderMapper.xml
+++ b/meta-bookdstore/src/main/resources/mapper/OrderMapper.xml
@@ -16,9 +16,11 @@
 
 		<selectKey keyProperty="order_no"
 			resultType="java.lang.String" order="AFTER">
-			SELECT (CONCAT(CONCAT(
-			to_char(sysdate,'yyyymmdd'),'-'),orders_seq.currval)) FROM dual
+			SELECT
+			(CONCAT(CONCAT(to_char(sysdate,'yyyymmdd'),'-'),orders_seq.currval))
+			FROM dual
 		</selectKey>
+
 	</insert>
 
 	<insert id="insertOrderItem">
@@ -30,13 +32,14 @@
 
 	</insert>
 
-	<select id="getOrderInfo"
-		resultType="com.meta.order.vo.OrderVO">
-		SELECT order_no, m_no, receiver_email,
+	<select id="getOrderInfo" resultType="com.meta.order.vo.OrderVO">
+		SELECT order_no, m_no,
+		receiver_email,
 		receiver_zipcode,
 		receiver_roadAddress,
 		receiver_otherAddress,receiver_phone,receiver_name,order_count,order_price,
-	to_char(order_date,'yyyy/mm/dd') order_date,status_code FROM orders WHERE order_no=#{order_no}
+		to_char(order_date,'yyyy/mm/dd') order_date,status_code FROM orders
+		WHERE order_no=#{order_no}
 	</select>
 
 	<select id="getOrderItems"
@@ -44,7 +47,4 @@
 		SELECT order_items.*, title,author FROM order_items, book
 		WHERE order_items.book_no = book.book_no AND order_no=#{order_no}
 	</select>
-
-
-
 </mapper>

--- a/meta-bookdstore/src/main/resources/static/js/ajax.js
+++ b/meta-bookdstore/src/main/resources/static/js/ajax.js
@@ -30,7 +30,6 @@ function addToCart(book_no, price) {
 	var quantity = $("[name=quantity]").val() !== undefined ? $("[name=quantity]").val() : 1;
 
 	var data = { book_no: book_no, cart_book_qt: quantity, cart_total_price: price * quantity };
-	console.log(data);
 	$.ajax({
 		url: "/cart/add",
 		type: "post",

--- a/meta-bookdstore/src/main/webapp/WEB-INF/views/book/details.jsp
+++ b/meta-bookdstore/src/main/webapp/WEB-INF/views/book/details.jsp
@@ -3,6 +3,7 @@
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c"%>
 <%@ taglib uri="http://www.springframework.org/security/tags"
 	prefix="sec"%>
+<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt"%>
 <sec:authorize access="isAuthenticated()">
 	<!-- isAuthenticated() : 인증된 정보(세션)에 접근하는 방법 -->
 	<sec:authentication property="principal" var="principal" />
@@ -59,17 +60,9 @@
 					<div class="container">
 						<div class="row space-2">
 							<div
-								class="col-md-6 col-lg-5 offset-lg-1 woocommerce-product-gallery woocommerce-product-gallery--with-images images">
-								<figure class="woocommerce-product-gallery__wrapper mb-6 b-md-0">
-									<div class="js-slick-carousel u-slick"
-										data-pagi-classes="position-absolute text-center left-0 u-slick__pagination flex-column u-slick__pagination-centered--y ml-md-n4 ml-lg-0 mr-lg-5 mb-0"
-										data-vertical="true">
-										<div class="js-slide">
-											<img src="${bookInfo.image}" alt="Image Description"
-												class="mx-auto img-fluid">
-										</div>
-									</div>
-								</figure>
+								class="d-flex align-items-center col-md-6 col-lg-5 offset-lg-1 woocommerce-product-gallery woocommerce-product-gallery--with-images images">
+								<img src="${bookInfo.image}" alt="Image Description"
+									class="mx-auto img-fluid" style="width: 35%;">
 							</div>
 							<div class="col-md-6 col-lg-5 summary entry-summary">
 								<div class="border bg-white">
@@ -77,20 +70,18 @@
 										<div class="border-bottom mb-4">
 											<h1 class="product_title entry-title font-size-26 mb-3">${bookInfo.title }</h1>
 											<div class="font-size-2 mb-4">
-												<span class="text-yellow-darker"> <span
-													class="fas fa-star"></span> <span class="fas fa-star"></span>
-													<span class="fas fa-star"></span> <span class="fas fa-star"></span>
-													<span class="fas fa-star"></span>
-												</span> <span class="ml-3">(3,714)</span> <span
-													class="ml-3 font-weight-medium">By (author)</span> <span
-													class="ml-2 text-gray-600">${bookInfo.author }</span>
+												<span class="ml-3 font-weight-medium">By (author)</span> 
+												<span class="ml-2 text-gray-600">${bookInfo.author}</span>
+												<span class="ml-3 font-weight-medium"> | </span>
+												<span class="ml-3">${bookInfo.publisher}</span> 
+												<span class="ml-3 font-weight-medium"> | </span>
+												<span class="ml-3">${bookInfo.pubdate}</span> 
 											</div>
 
 										</div>
 										<p class="price font-size-22 font-weight-medium mb-4">
-											<span class="woocommerce-Price-amount amount">가격 :
-												${bookInfo.price} <span
-												class="woocommerce-Price-currencySymbol">원</span>
+											<span class="woocommerce-Price-amount amount">가격 : <fmt:formatNumber
+													value="${bookInfo.price}" pattern="###,###"></fmt:formatNumber>원
 											</span>
 										</p>
 
@@ -168,37 +159,9 @@
 						<div
 							class="woocommerce-Tabs-panel panel col-xl-8 offset-xl-2 entry-content wc-tab tab-pane fade pt-9 show active"
 							id="pills-one-example1" role="tabpanel"
-							aria-labelledby="pills-one-example1-tab">
-							<!-- Mockup Block -->
-							<p class="mb-0">We aim to show you accurate product
-								information. Manufacturers, suppliers and others provide what
-								you see here, and we have not verified it. See our disclaimer</p>
-							<p class="mb-0">#1 New York Times Bestseller</p>
-							<p class="mb-0">A Reese Witherspoon x Hello Sunshine Book
-								Club Pick</p>
-							<p class="mb-4">"I can't even express how much I love this
-								book! I didn't want this story to end!"--Reese Witherspoon</p>
-							<p class="mb-4">"Painfully beautiful."--The New York Times
-								Book Review</p>
-							<p>"Perfect for fans of Barbara Kingsolver."--Bustle</p>
-							<p class="mb-4">For years, rumors of the "Marsh Girl" have
-								haunted Barkley Cove, a quiet town on the North Carolina coast.
-								So in late 1969, when handsome Chase Andrews is found dead, the
-								locals immediately suspect Kya Clark, the so-called Marsh Girl.
-								But Kya is not what they say. Sensitive and intelligent, she has
-								survived for years alone in the marsh that she calls home,
-								finding friends in the gulls and lessons in the sand. Then the
-								time comes when she yearns to be touched and loved. When two
-								young men from town become intrigued by her wild beauty, Kya
-								opens herself to a new life--until the unthinkable happens.</p>
-							<p class="mb-4">Perfect for fans of Barbara Kingsolver and
-								Karen Russell, Where the Crawdads Sing is at once an exquisite
-								ode to the natural world, a heartbreaking coming-of-age story,
-								and a surprising tale of possible murder. Owens reminds us that
-								we are forever shaped by the children we once were, and that we
-								are all subject to the beautiful and violent secrets that nature
-								keeps</p>
-							<p>WHERE THE CRAWDADS LP</p>
+							aria-labelledby="pills-one-example1-tab"
+							style="font-size: 1.135rem;">
+							${bookInfo.description}
 							<!-- End Mockup Block -->
 						</div>
 					</div>


### PR DESCRIPTION
## 🔥  무슨 내용의 PR인가요?

-네이버에서 제공해주는 book API 책 상세정보 페이지에서 descriptoin 파트를 스크래핑 해오는 기능 추가 
- 웹 스크래핑 후 book 테이블 description 컬럼에 값 추가 

<br>

## 🔑  주된 변경점

- 네이버에서 제공하는 book API의 description(summary)이 아닌 웹 스크래핑을 통해 직접 해당 description 데이터 추출  
- 책 상세정보 페이지에 추가한 description 정보 출력 
- 책 상세정보 페이지 이미지 크기 조절 
<br>

## 🙏  To Reviewers

- Book테이블의 description 컬럼 데이터 타입을 수정해주세요. 
- Book테이블 내용 다 지운 후 다시 데이터 받아와 주세요. (웹 스크래핑 작업으로 인해 시간이 다소 걸릴 수 있습니다.)
- 웹 스크래핑에서 http 요청을 하지 못하는 링크가 있었습니다. 데이터 다 받아온 후 description이 null인 경우  slack 게시판을 참고하여 따로 데이터를 넣어주세요. 

<br>
