### PR TITLE
feat: stock 초기화 기능 추가

### DIFF
--- a/meta-bookdstore/src/main/java/com/meta/api2/controller/ApiController.java
+++ b/meta-bookdstore/src/main/java/com/meta/api2/controller/ApiController.java
@@ -1,8 +1,17 @@
 package com.meta.api2.controller;
 
-import com.google.gson.Gson;
-import com.meta.api2.service.ApiService;
-import com.meta.api2.vo.ApiVo;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.UnsupportedEncodingException;
+import java.net.HttpURLConnection;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLEncoder;
+import java.util.HashMap;
+import java.util.Map;
+
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.jsoup.Jsoup;
@@ -13,19 +22,18 @@ import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 
-import java.io.*;
-import java.net.HttpURLConnection;
-import java.net.MalformedURLException;
-import java.net.URL;
-import java.net.URLEncoder;
-import java.util.HashMap;
-import java.util.Map;
+import com.google.gson.Gson;
+import com.meta.api2.service.ApiService;
+import com.meta.api2.vo.ApiVo;
+import com.meta.stock.service.StockService;
 
 @Controller
 public class ApiController {
 
 	@Autowired
 	private ApiService apiService;
+	@Autowired
+	private StockService stockService;
 
 	@RequestMapping("api/insert/book/{no}")
 	public void main(@PathVariable int no) {
@@ -83,6 +91,7 @@ public class ApiController {
 				}finally{
 					index++;
 					apiService.insert(apiVo);
+					stockService.initializeStock(apiVo.getBook_no());
 				}
 
 			

--- a/meta-bookdstore/src/main/java/com/meta/api2/vo/ApiVo.java
+++ b/meta-bookdstore/src/main/java/com/meta/api2/vo/ApiVo.java
@@ -5,7 +5,7 @@ import lombok.Data;
 
 @Data
 public class ApiVo {
-	private int book_no;
+	private long book_no;
 	private String title;
 	private String image;
 	private String author;

--- a/meta-bookdstore/src/main/java/com/meta/stock/controller/StockController.java
+++ b/meta-bookdstore/src/main/java/com/meta/stock/controller/StockController.java
@@ -1,0 +1,8 @@
+package com.meta.stock.controller;
+
+import org.springframework.stereotype.Controller;
+
+@Controller
+public class StockController {
+
+}

--- a/meta-bookdstore/src/main/java/com/meta/stock/mapper/StockMapper.java
+++ b/meta-bookdstore/src/main/java/com/meta/stock/mapper/StockMapper.java
@@ -1,0 +1,10 @@
+package com.meta.stock.mapper;
+
+import org.apache.ibatis.annotations.Mapper;
+
+@Mapper
+public interface StockMapper {
+	
+	public int initializeStock(long book_no);
+
+}

--- a/meta-bookdstore/src/main/java/com/meta/stock/service/StockService.java
+++ b/meta-bookdstore/src/main/java/com/meta/stock/service/StockService.java
@@ -1,0 +1,19 @@
+package com.meta.stock.service;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import com.meta.stock.mapper.StockMapper;
+
+
+
+@Service
+public class StockService {
+	
+	@Autowired
+	private StockMapper mapper;
+	
+	public int initializeStock(long book_no) {
+		return mapper.initializeStock(book_no);
+	}
+}

--- a/meta-bookdstore/src/main/java/com/meta/stock/vo/StockVO.java
+++ b/meta-bookdstore/src/main/java/com/meta/stock/vo/StockVO.java
@@ -1,0 +1,12 @@
+package com.meta.stock.vo;
+
+import lombok.Data;
+
+@Data
+public class StockVO {
+
+	private long stock_no;
+	private int stock;
+	private long book_no; 
+	private int sold_cnt;
+}

--- a/meta-bookdstore/src/main/resources/mapper/ApiMapper.xml
+++ b/meta-bookdstore/src/main/resources/mapper/ApiMapper.xml
@@ -9,5 +9,10 @@
 		INSERT INTO book (book_no, title, author, publisher, pubdate, description,
 		image, price,cate_no )
 		values(seq_book_no.nextval,#{title},#{author},#{publisher},to_date(#{pubdate},'yyyy-mm-dd'),#{description},#{image},#{price},#{cate_no})
+		
+		<selectKey keyProperty="book_no"
+			resultType="long" order="AFTER">
+			SELECT seq_book_no.currval FROM dual
+		</selectKey>
 	</insert>
 </mapper>

--- a/meta-bookdstore/src/main/resources/mapper/StockMapper.xml
+++ b/meta-bookdstore/src/main/resources/mapper/StockMapper.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper
+  PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+  "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.meta.stock.mapper.StockMapper">
+	<!-- 1.북 리스트 보기 -->
+
+	<insert id="initializeStock">
+		INSERT INTO stock (stock_no, stock, book_no)
+		VALUES (stock_seq.nextval, 100, #{book_no})
+	</insert>
+
+</mapper>


### PR DESCRIPTION
## 🔥  무슨 내용의 PR인가요?

- 책 api를 통해 책 정보 받아올 때 각 책별 재고값 초기화 기능 추가 
 
<br>

## 🔑  주된 변경점

- 재고값 100권으로 초기화 진행

<br>

## 🙏  To Reviewers

- DELETE FROM book 실행 후 
- 책 정보 다시 받아와 주세요. (100,110,120,130,140,150,160 총 7번, 140권)
- slack에 올려놓은 update쿼리 실행해주세요. (description이 null인 경우)
- SELECT * FROM book, stock WHERE book.book_no = stock.book_no 실행하여 총 140권이 나오는지 확인해 주세요. 

<br>
